### PR TITLE
Add the ability to deal with task duplicates

### DIFF
--- a/src/main/java/baron/message/Message.java
+++ b/src/main/java/baron/message/Message.java
@@ -54,4 +54,14 @@ public class Message {
         assert taskCount >= 0 : "taskCount should be >= 0";
         return "The task index is invalid, only accepts 1 to " + taskCount + ".";
     }
+
+    /**
+     * Generate the message to warn that duplicate tasks have been detected.
+     *
+     * @param taskType the type of task.
+     * @return the message to warn that duplicate tasks have been detected.
+     */
+    public static String generateDuplicateTaskMessage(TaskType taskType) {
+        return String.format("This %s has already been recorded.", taskType.getCommand());
+    }
 }

--- a/src/main/java/baron/tasks/Deadline.java
+++ b/src/main/java/baron/tasks/Deadline.java
@@ -25,6 +25,33 @@ public class Deadline extends Task {
     }
 
     /**
+     * Checks if this {@code Deadline} object is equal to the specified object.
+     *
+     * @param o an {@code Object} to be compared with.
+     * @return true if the specified object equals to this {@code Deadline} object.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null) {
+            return false;
+        }
+
+        if (!(o instanceof Deadline)) {
+            return false;
+        }
+
+        Deadline deadline = (Deadline) o;
+        boolean isDescriptionEqual = this.description.equals(deadline.description);
+        boolean isByEqual = this.by.equals(deadline.by);
+
+        return isDescriptionEqual && isByEqual;
+    }
+
+    /**
      * Returns the string representation of this {@code Deadline} task.
      *
      * @return the string representation of this {@code Deadline} task.

--- a/src/main/java/baron/tasks/Event.java
+++ b/src/main/java/baron/tasks/Event.java
@@ -25,6 +25,33 @@ public class Event extends Task {
     }
 
     /**
+     * Checks if this {@code Event} object is equal to the specified object.
+     *
+     * @param o an {@code Object} to be compared with.
+     * @return true if the specified object equals to this {@code Event} object.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null) {
+            return false;
+        }
+
+        if (!(o instanceof Event)) {
+            return false;
+        }
+
+        Event event = (Event) o;
+        boolean isDescriptionEqual = this.description.equals(event.description);
+        boolean isAtEqual = this.at.equals(event.at);
+
+        return isDescriptionEqual && isAtEqual;
+    }
+
+    /**
      * Returns the string representation of this {@code Event} task.
      *
      * @return the string representation of this {@code Event} task.

--- a/src/main/java/baron/tasks/Task.java
+++ b/src/main/java/baron/tasks/Task.java
@@ -53,10 +53,20 @@ public abstract class Task {
     }
 
     /**
+     * Checks if this {@code Task} object is equal to the specified object.
+     *
+     * @param o an {@code Object} to be compared with.
+     * @return true if the specified object equals to this {@code Task} object.
+     */
+    @Override
+    public abstract boolean equals(Object o);
+
+    /**
      * Returns the string representation of this task.
      *
      * @return the string representation of this task.
      */
+    @Override
     public String toString() {
         return "[" + this.getStatusIcon() + "] " + description;
     }

--- a/src/main/java/baron/tasks/TaskManager.java
+++ b/src/main/java/baron/tasks/TaskManager.java
@@ -111,6 +111,10 @@ public class TaskManager {
             newTask = new Event(commandArgs[0], localDateTime);
         }
 
+        if (this.taskList.contains(newTask)) {
+            throw new BaronException(Message.generateDuplicateTaskMessage(taskType));
+        }
+
         this.taskList.add(newTask);
         this.previousTaskList = this.getAllTasks();
         return newTask;

--- a/src/main/java/baron/tasks/ToDo.java
+++ b/src/main/java/baron/tasks/ToDo.java
@@ -17,6 +17,31 @@ public class ToDo extends Task {
     }
 
     /**
+     * Checks if this {@code ToDo} object is equal to the specified object.
+     *
+     * @param o an {@code Object} to be compared with.
+     * @return true if the specified object equals to this {@code ToDo} object.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null) {
+            return false;
+        }
+
+        if (!(o instanceof ToDo)) {
+            return false;
+        }
+
+        ToDo toDo = (ToDo) o;
+
+        return this.description.equals(toDo.description);
+    }
+
+    /**
      * Returns the string representation of this {@code ToDo} task.
      *
      * @return the string representation of this {@code ToDo} task.


### PR DESCRIPTION
Duplicated task (Deadline, ToDo, Event) can be added into the
TaskManager, which is redundant to the user.

This update prevents user from adding duplicated tasks.

Let's,
* add an abstract equals(Object) method to Task
* implement equals(Object) method in Task's subclasses
* add a duplicate check in addTask(TaskType, String) in TaskManager
* add generateDuplicateTaskMessage(TaskType) in Message

This uses the power of polymorphism by leveraging the use of the equal
method of Object and overriding it in subclasses, so minimal edits were
made.

Event objects are equal when description and at variables are equal.

Deadline objects are equal when description and at variables are equal.

ToDo objects are equal when description variables are equal